### PR TITLE
Env variables fix 

### DIFF
--- a/examples/configs/cxworker-bare-env.yml
+++ b/examples/configs/cxworker-bare-env.yml
@@ -3,7 +3,7 @@ registry:
   url: ${REGISTRY_URL}
 storage:
   url: $STORAGE_URL
-  access_key: ${STORAGE_ACCESS_KEY}
+  access_key: $321/$STORAGE_ACCESS_KEY
   secret_key: $_STORAGE_SECRET_KEY
 sheep:
   bare_sheep:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask
 Flask-CORS
 simplejson
 pyzmq
-greenlet==0.4.13  # TODO: dirty hack by @Teyras
 gevent
 PyYaml
 requests

--- a/tests/shepherd/conftest.py
+++ b/tests/shepherd/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 import json
-import os.path as path
 from io import BytesIO
 import os.path as path
 

--- a/tests/shepherd/test_config.py
+++ b/tests/shepherd/test_config.py
@@ -48,7 +48,7 @@ def test_load_config_valid_env(valid_config_env_file):
 
     assert config.registry.url == os.environ['REGISTRY_URL']
     assert config.storage.url == os.environ['STORAGE_URL']
-    assert config.storage.access_key == os.environ['STORAGE_ACCESS_KEY']
+    assert config.storage.access_key == os.path.join('$321', os.environ['STORAGE_ACCESS_KEY'])
     assert config.storage.secret_key == os.environ['_STORAGE_SECRET_KEY']
 
     assert config.sheep['bare_sheep']['type'] == 'bare'
@@ -92,5 +92,7 @@ def test_load_config_invalid_env_name(invalid_config_env_file):
 
 
 def test_invalid_config(invalid_config_file):
-    with pytest.raises(DataError), open(invalid_config_file) as file:
-        load_worker_config(file)
+    with pytest.raises(DataError):
+        with open(invalid_config_file) as file:
+            load_worker_config(file)
+


### PR DESCRIPTION
Strings containing variables like $321/$ENV_VAR were not correctly replaced with ENV variables. This should fix it. It also refactors code to use only one regex with conditions to match both ENV vars with and without brackets. PR references issue #66. 
